### PR TITLE
Update registration-user.html.twig

### DIFF
--- a/Resources/themes/default/templates/security/emails/registration-user.html.twig
+++ b/Resources/themes/default/templates/security/emails/registration-user.html.twig
@@ -1,4 +1,4 @@
-{% set confirmationUrl = app.request.schemeAndHttpHost ~ path(request.portalUrl ~ '.l91_sulu_website_user.confirmation', {'token': user.confirmationKey}) %}
+{% set confirmationUrl = app.request.schemeAndHttpHost ~ path('l91_sulu_website_user.registration',{'host': request.portalUrl, 'prefix': ''}) %}
 
 <a href="{{ confirmationUrl }}">
     {{ confirmationUrl }}

--- a/Resources/themes/default/templates/security/emails/registration-user.html.twig
+++ b/Resources/themes/default/templates/security/emails/registration-user.html.twig
@@ -1,4 +1,4 @@
-{% set confirmationUrl = app.request.schemeAndHttpHost ~ path('l91_sulu_website_user.registration',{'host': request.portalUrl, 'prefix': ''}) %}
+{% set confirmationUrl = app.request.schemeAndHttpHost ~ path('l91_sulu_website_user.confirmation', request.routeParameters) %}
 
 <a href="{{ confirmationUrl }}">
     {{ confirmationUrl }}


### PR DESCRIPTION
I had an error like this: `An exception has been thrown during the rendering of a template ("None of the chained routers were able to generate route: Route 'tcbase.lo/fa.l91_sulu_website_user.login_check' not found") in ::templates\security\login.html.twig at line 3.` so I changed all lines like `path(request.portalUrl ~ '.l91_sulu_website_user`
