### PR TITLE
Update password-forget-user.html.twig

### DIFF
--- a/Resources/themes/default/templates/security/emails/password-forget-user.html.twig
+++ b/Resources/themes/default/templates/security/emails/password-forget-user.html.twig
@@ -1,4 +1,4 @@
-{% set passwordForgetUrl = app.request.schemeAndHttpHost ~ path('l91_sulu_website_user.password_reset',{'host': request.portalUrl, 'prefix': '', 'token': user.passwordResetToken}) %}
+{% set passwordForgetUrl = app.request.schemeAndHttpHost ~ path('l91_sulu_website_user.password_reset', request.routeParameters) %}
 
 <a href="{{ passwordForgetUrl }}">
     {{ passwordForgetUrl }}

--- a/Resources/themes/default/templates/security/emails/password-forget-user.html.twig
+++ b/Resources/themes/default/templates/security/emails/password-forget-user.html.twig
@@ -1,4 +1,4 @@
-{% set passwordForgetUrl = app.request.schemeAndHttpHost ~ path(request.portalUrl ~ '.l91_sulu_website_user.password_reset', {'token': user.passwordResetToken}) %}
+{% set passwordForgetUrl = app.request.schemeAndHttpHost ~ path('l91_sulu_website_user.password_reset',{'host': request.portalUrl, 'prefix': '', 'token': user.passwordResetToken}) %}
 
 <a href="{{ passwordForgetUrl }}">
     {{ passwordForgetUrl }}


### PR DESCRIPTION
I had an error like this: `An exception has been thrown during the rendering of a template ("None of the chained routers were able to generate route: Route 'tcbase.lo/fa.l91_sulu_website_user.login_check' not found") in ::templates\security\login.html.twig at line 3.` so I changed all lines like `path(request.portalUrl ~ '.l91_sulu_website_user`
